### PR TITLE
Use space :align-to instead of manual computations

### DIFF
--- a/elegant.el
+++ b/elegant.el
@@ -154,8 +154,9 @@ background color that is barely perceptible."
 
 (defun mode-line-render (left right)
   "Function to render the modeline LEFT to RIGHT."
-  (let* ((available-width (- (window-width) (length left) )))
-    (format (format "%%s %%%ds" available-width) left right)))
+  (concat left
+          (propertize " " 'display `(space :align-to (- right ,(length right))))
+          right))
 (setq-default mode-line-format
      '((:eval
        (mode-line-render


### PR DESCRIPTION
Fixes #29 

----

Looking at marginalia.el issues, code, and [the README](https://github.com/minad/marginalia/tree/main#adding-custom-annotators-or-classifiers) I found out about alignment propertization, and that fixes the problem of chopped-off characters for me:

```elisp
(defun mode-line-render (left right)
  "Function to render the modeline LEFT to RIGHT."
  (concat left
          (propertize " "
                      'display `(space :align-to (- right ,(length right))))
          right))
```

You can also easily add a middle column later if you want:

```elisp
(defun mode-line-render (left center right)
  "Function to render the modeline LEFT, CENTER, and RIGHT."
  (concat left
          (propertize " "
                      'display `(space :align-to (- center ,(length center))))
          center
          (propertize " "
                      'display `(space :align-to (- right ,(length right))))
          right))
```

With the space alignment stuff here, this even works on a **per-pixel offset basis** -- I can freely resize the window and the line and column indicators stick to the window edges.

Compare with 

    (setq frame-resize-pixelwise t)

... and you'll see that the current approach moves in units of 1 character, while this PR will move per pixel.